### PR TITLE
ci: refactor workflows with reusable build and add cargo-bundle caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,183 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      upload-artifact:
+        description: 'Upload build artifacts'
+        required: false
+        default: true
+        type: boolean
+      artifact-retention-days:
+        description: 'Artifact retention days'
+        required: false
+        default: 7
+        type: number
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            fakeroot dpkg-dev \
+            libxcb-shape0-dev libxcb-xfixes0-dev \
+            libxkbcommon-dev libxkbcommon-x11-dev \
+            libwayland-dev libvulkan-dev libssl-dev \
+            libglib2.0-dev libgtk-3-dev \
+            libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \
+            libxdo-dev pkg-config
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo-bundle
+        id: cache-cargo-bundle-linux
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-bundle
+          key: cargo-bundle-${{ runner.os }}-v1
+
+      - name: Install cargo-bundle
+        if: steps.cache-cargo-bundle-linux.outputs.cache-hit != 'true'
+        run: cargo install cargo-bundle
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release
+        run: cargo build --release --locked
+
+      - name: Create DEB package
+        run: |
+          cargo bundle --release
+          package=$(ls target/release/bundle/deb/*.deb | head -n 1)
+          cp "$package" agentx-linux.deb
+
+      - name: Create tarball
+        run: |
+          mkdir -p agentx-linux
+          cp target/release/agentx agentx-linux/
+          chmod +x agentx-linux/agentx
+          tar -czvf agentx-linux.tar.gz agentx-linux
+
+      - name: Upload Linux artifact
+        if: ${{ inputs.upload-artifact }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentx-linux
+          path: |
+            agentx-linux.deb
+            agentx-linux.tar.gz
+          retention-days: ${{ inputs.artifact-retention-days }}
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo-bundle
+        id: cache-cargo-bundle-macos
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-bundle
+          key: cargo-bundle-${{ runner.os }}-v1
+
+      - name: Install cargo-bundle
+        if: steps.cache-cargo-bundle-macos.outputs.cache-hit != 'true'
+        run: cargo install cargo-bundle
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release
+        run: cargo build --release --locked
+
+      - name: Create app bundle
+        run: cargo bundle --release
+
+      - name: Sign application (ad-hoc)
+        run: |
+          codesign --force --deep -s - target/release/bundle/osx/AgentX.app
+          codesign --verify --verbose target/release/bundle/osx/AgentX.app
+
+      - name: Install create-dmg
+        run: brew install create-dmg
+
+      - name: Create DMG
+        run: |
+          create-dmg \
+            --volname "AgentX" \
+            --window-size 600 400 \
+            --icon-size 100 \
+            --icon "AgentX.app" 150 190 \
+            --app-drop-link 450 185 \
+            "agentx-macos.dmg" \
+            "target/release/bundle/osx/AgentX.app"
+
+      - name: Upload macOS artifact
+        if: ${{ inputs.upload-artifact }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentx-macos
+          path: agentx-macos.dmg
+          retention-days: ${{ inputs.artifact-retention-days }}
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install WiX Toolset
+        run: choco install wixtoolset --no-progress
+
+      - name: Cache cargo-bundle
+        id: cache-cargo-bundle-windows
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-bundle.exe
+          key: cargo-bundle-${{ runner.os }}-v1
+
+      - name: Install cargo-bundle
+        if: steps.cache-cargo-bundle-windows.outputs.cache-hit != 'true'
+        run: cargo install cargo-bundle
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release
+        run: cargo build --release --locked
+
+      - name: Create MSI installer
+        shell: bash
+        run: |
+          cargo bundle --release
+          installer=$(ls target/release/bundle/msi/*.msi | head -n 1)
+          cp "$installer" agentx-windows.msi
+
+      - name: Create portable executable
+        shell: bash
+        run: cp target/release/agentx.exe agentx-windows.exe
+
+      - name: Upload Windows artifact
+        if: ${{ inputs.upload-artifact }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentx-windows
+          path: |
+            agentx-windows.msi
+            agentx-windows.exe
+          retention-days: ${{ inputs.artifact-retention-days }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: Build & Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libxdo-dev libgtk-3-dev libglib2.0-dev libcairo2-dev \
+            libpango1.0-dev libatk1.0-dev libgdk-pixbuf-2.0-dev \
+            libxcb1-dev libxcb-render0-dev libxcb-shape0-dev \
+            libxcb-xfixes0-dev libxkbcommon-dev libxkbcommon-x11-dev \
+            libasound2-dev libwayland-dev libvulkan-dev
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check Cargo.lock consistency
+        run: cargo generate-lockfile --locked
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Cargo check
+        run: cargo check --locked
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --locked -- -D warnings
+
+      - name: Run tests
+        run: cargo test --locked

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,18 @@
+name: Nightly Build
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # 每天 UTC 0:00
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+    with:
+      upload-artifact: true
+      artifact-retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,183 +11,23 @@ on:
         required: true
         type: string
 
-env:
-  CARGO_TERM_COLOR: always
-  CARGO_NET_GIT_FETCH_WITH_CLI: true
-
 jobs:
-  build-macos:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure git for private deps
-        run: git config --global url."https://x-access-token:${{ secrets.GPUI_TOKEN }}@github.com/".insteadOf "https://github.com/"
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install cargo-bundle
-        run: cargo install cargo-bundle
-
-      - name: Build release
-        # working-directory: agent-studio
-        run: cargo build --release
-
-      - name: Create app bundle
-        # working-directory: agent-studio
-        run: cargo bundle --release
-
-      - name: Sign application (ad-hoc)
-        # working-directory: agent-studio
-        run: |
-          codesign --force --deep -s - target/release/bundle/osx/AgentX.app
-          codesign --verify --verbose target/release/bundle/osx/AgentX.app
-
-      - name: Install create-dmg
-        run: brew install create-dmg
-
-      - name: Create DMG
-        # working-directory: agent-studio
-        run: |
-          create-dmg \
-            --volname "AgentX" \
-            --window-size 600 400 \
-            --icon-size 100 \
-            --icon "AgentX.app" 150 190 \
-            --app-drop-link 450 185 \
-            "agentx-macos.dmg" \
-            "target/release/bundle/osx/AgentX.app"
-
-      - name: Upload DMG artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: agentx-macos
-          path: agentx-macos.dmg
-
-  build-windows:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure git for private deps
-        run: git config --global url."https://x-access-token:${{ secrets.GPUI_TOKEN }}@github.com/".insteadOf "https://github.com/"
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install WiX Toolset
-        run: choco install wixtoolset --no-progress
-
-      - name: Install cargo-bundle
-        run: cargo install cargo-bundle
-
-      - name: Build release
-        # working-directory: agent-studio
-        run: cargo build --release
-
-      - name: Create MSI installer
-        shell: bash
-        run: |
-          cargo bundle --release
-          installer=$(ls target/release/bundle/msi/*.msi | head -n 1)
-          cp "$installer" agentx-windows.msi
-
-      - name: Create portable executable
-        shell: bash
-        run: cp target/release/agentx.exe agentx-windows.exe
-
-      - name: Upload Windows artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: agentx-windows
-          path: |
-            agentx-windows.exe
-            agentx-windows.msi
-
-  build-linux:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure git for private deps
-        run: git config --global url."https://x-access-token:${{ secrets.GPUI_TOKEN }}@github.com/".insteadOf "https://github.com/"
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            fakeroot \
-            dpkg-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev \
-            libxkbcommon-dev \
-            libxkbcommon-x11-dev \
-            libwayland-dev \
-            libvulkan-dev \
-            libssl-dev \
-            libglib2.0-dev \
-            libgtk-3-dev \
-            libwebkit2gtk-4.1-dev \
-            libjavascriptcoregtk-4.1-dev \
-            libxdo-dev \
-            pkg-config
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install cargo-bundle
-        run: cargo install cargo-bundle
-
-      - name: Build release
-        # working-directory: agent-studio
-        run: cargo build --release
-
-      - name: Create DEB package
-        run: |
-          cargo bundle --release
-          package=$(ls target/release/bundle/deb/*.deb | head -n 1)
-          cp "$package" agentx-linux.deb
-
-      - name: Create tarball
-        run: |
-          mkdir -p agentx-linux
-          cp target/release/agentx agentx-linux/agentx
-          chmod +x agentx-linux/agentx
-          tar -czvf agentx-linux.tar.gz agentx-linux
-
-      - name: Upload Linux artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: agentx-linux
-          path: |
-            agentx-linux.tar.gz
-            agentx-linux.deb
+  build:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+    with:
+      upload-artifact: true
+      artifact-retention-days: 90
 
   release:
-    needs: [build-macos, build-windows, build-linux]
+    needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
     steps:
-      - name: Download macOS artifact
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
-        with:
-          name: agentx-macos
-
-      - name: Download Windows artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: agentx-windows
-
-      - name: Download Linux artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: agentx-linux
 
       - name: Get version
         id: version
@@ -206,58 +46,16 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            agentx-macos.dmg
-            agentx-windows.msi
-            agentx-windows.exe
-            agentx-linux.deb
-            agentx-linux.tar.gz
+            agentx-macos/agentx-macos.dmg
+            agentx-windows/agentx-windows.msi
+            agentx-windows/agentx-windows.exe
+            agentx-linux/agentx-linux.deb
+            agentx-linux/agentx-linux.tar.gz
           body: |
             ## AgentX - AI Agent Studio
 
-            A full-featured desktop AI agent studio built with GPUI Component.
+            ### Installation
 
-            ### Features
-            - Dock-based layout system with persistent state
-            - Real-time agent communication via Agent Client Protocol (ACP)
-            - Multi-session management with JSONL persistence
-            - Code editor with LSP integration and syntax highlighting
-            - Auto-update system with version checking
-            - Light/dark theme support
-
-            ## Installation
-
-            ### macOS
-            1. Download `agentx-macos.dmg`
-            2. Open the DMG and drag AgentX to Applications
-            3. On first launch: right-click the app > Open > Open (to bypass Gatekeeper)
-
-            ### Windows
-            1. Download `agentx-windows.msi`
-            2. Run the installer
-            3. You may need to allow the app through Windows Defender SmartScreen
-            4. (Optional) `agentx-windows.exe` is a portable build
-
-            ### Linux
-            1. Download `agentx-linux.deb`
-            2. Install: `sudo dpkg -i agentx-linux.deb`
-            3. Fix deps if needed: `sudo apt-get -f install`
-            4. (Optional) `agentx-linux.tar.gz` is a portable build
-            5. Ensure required dependencies are installed (Vulkan, GTK3, etc.)
-
-            ## Configuration
-
-            Create a `config.json` in the same directory as the executable:
-
-            ```json
-            {
-              "agent_servers": [
-                {
-                  "name": "my-agent",
-                  "command": "/path/to/agent/executable",
-                  "args": ["--arg1", "value1"]
-                }
-              ]
-            }
-            ```
-
-            For more details, see the [README](https://github.com/your-org/gpui-component/tree/main/agent-studio).
+            **macOS**: Download `agentx-macos.dmg`, drag to Applications
+            **Windows**: Download `agentx-windows.msi` or portable `agentx-windows.exe`
+            **Linux**: Download `agentx-linux.deb` and run `sudo dpkg -i agentx-linux.deb`

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 # Build artifacts
 /target
 *.pdb
-.github
+
 # Session data
 /sessions
 /docs
+
 # Application state
 /docks-layout.json
 /state.json


### PR DESCRIPTION
## Summary

- Add `build.yml` as reusable workflow (`workflow_call`)
- Add `ci.yml` for PR/push checks (fmt, clippy, test)
- Add `nightly.yml` with cron schedule (UTC 0:00) instead of push trigger
- Refactor `release.yml` to call `build.yml`, reducing duplication
- Remove private dependency config (`GPUI_TOKEN`, `git config`)
- Add cargo-bundle caching for all platforms
- Remove `.github` from `.gitignore` to track CI files

## Workflow Triggers

| Event | ci.yml | nightly.yml | release.yml |
|-------|--------|-------------|-------------|
| PR to main | ✅ | - | - |
| Push to main | ✅ | - | - |
| Daily UTC 0:00 | - | ✅ | - |
| Tag v* push | - | - | ✅ |
| Manual dispatch | - | ✅ | ✅ |

## Test Plan

- [ ] Push PR: verify only `ci.yml` triggers
- [ ] Merge to main: verify only `ci.yml` triggers (nightly no longer auto-triggers)
- [ ] Manual trigger nightly: verify build completes on Actions page
- [ ] Wait for scheduled trigger: confirm UTC 0:00 nightly build works
- [ ] Push tag: verify `release.yml` creates GitHub Release