### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,10 +329,10 @@ Special thanks to:
 ## Star History
 
 <p align="center">
-  <a href="https://star-history.com/#sxhxliang/agent-studio&Date">
+  <a href="https://star-history.dera.page/#sxhxliang/agent-studio&Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=sxhxliang/agent-studio&type=Date&theme=dark"/>
-      <img src="https://api.star-history.com/svg?repos=sxhxliang/agent-studio&type=Date" alt="Star History Chart"/>
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=sxhxliang/agent-studio&type=Date&theme=dark"/>
+      <img src="https://star-history.dera.page/svg?repos=sxhxliang/agent-studio&type=Date" alt="Star History Chart"/>
     </picture>
   </a>
 </p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -335,10 +335,10 @@ RUST_LOG=info cargo run
 ## Star History
 
 <p align="center">
-  <a href="https://star-history.com/#sxhxliang/agent-studio&Date">
+  <a href="https://star-history.dera.page/#sxhxliang/agent-studio&Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=sxhxliang/agent-studio&type=Date&theme=dark"/>
-      <img src="https://api.star-history.com/svg?repos=sxhxliang/agent-studio&type=Date" alt="Star History Chart"/>
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=sxhxliang/agent-studio&type=Date&theme=dark"/>
+      <img src="https://star-history.dera.page/svg?repos=sxhxliang/agent-studio&type=Date" alt="Star History Chart"/>
     </picture>
   </a>
 </p>


### PR DESCRIPTION
The star history chart in our README is currently broken and shows nothing to visitors. This PR updates the chart links and image URLs so the star history chart displays correctly again in both the English and Chinese README files.